### PR TITLE
Add missing sudo on certbot execution

### DIFF
--- a/install-deb.sh
+++ b/install-deb.sh
@@ -495,7 +495,7 @@ read HOSTNAME
   echo "What is your email? - Needed for Letsencrypt Alerts"
   read EMAIL
 
-  if certbot certonly --standalone -d $DOMAIN -m $EMAIL --agree-tos --non-interactive; then
+  if sudo certbot certonly --standalone -d $DOMAIN -m $EMAIL --agree-tos --non-interactive; then
     echo "Certificate obtained successfully!"
     CERT_NAME=$(sudo certbot certificates | grep -oP "(?<=Certificate Name: ).*")
   else


### PR DESCRIPTION
Cause "Cert Setup Script exists but is not executable, are you running this as root?" if script not run as root